### PR TITLE
fix(cookies): MEN-91 | rename login cookie to force signouts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,24 +26,24 @@ const useStyles = createUseStyles((theme: DefaultTheme) => ({
 function App() {
   const classes = useStyles();
   const [currentUser, setCurrentUser] = useState<CurrentUser>(null);
-  const [cookies] = useCookies(["growth_10"]);
+  const [cookies] = useCookies(["growth_10_03142023"]);
 
   useEffect(() => {
-    if (cookies.growth_10) {
+    if (cookies.growth_10_03142023) {
       setCurrentUser({
-        id: cookies.growth_10.id,
+        id: cookies.growth_10_03142023.id,
 
         // leaving backward compatibility for now
-        first_name: cookies.growth_10.name
-          ? cookies.growth_10.name.split(" ")[0]
-          : cookies.growth_10.first_name,
-        last_name: cookies.growth_10.name
-          ? cookies.growth_10.name.split(" ")[1]
-          : cookies.growth_10.last_name,
+        first_name: cookies.growth_10_03142023.name
+          ? cookies.growth_10_03142023.name.split(" ")[0]
+          : cookies.growth_10_03142023.first_name,
+        last_name: cookies.growth_10_03142023.name
+          ? cookies.growth_10_03142023.name.split(" ")[1]
+          : cookies.growth_10_03142023.last_name,
         //
 
-        email: cookies.growth_10.email,
-        employer_id: cookies.growth_10.employer_id,
+        email: cookies.growth_10_03142023.email,
+        employer_id: cookies.growth_10_03142023.employer_id,
       });
     }
   }, [cookies]);
@@ -117,7 +117,7 @@ function App() {
           <Route
             path="/sign-up"
             element={
-              !currentUser || !cookies.growth_10 ? (
+              !currentUser || !cookies.growth_10_03142023 ? (
                 <Register
                   setCurrentUser={setCurrentUser}
                   currentUser={currentUser}

--- a/src/components/LoginForm/index.tsx
+++ b/src/components/LoginForm/index.tsx
@@ -25,7 +25,7 @@ const LoginForm: React.FC<UserLoginProps> = (props) => {
   const [password, setPassword] = useState<string>(null);
   const [emailError, setEmailError] = useState<boolean>(false);
   const [passwordError, setPasswordError] = useState<boolean>(false);
-  const [, setCookie] = useCookies(["growth_10", "growth_10_token"]);
+  const [, setCookie] = useCookies(["growth_10_03142023", "growth_10_token"]);
 
   const validateEmail = () => {
     if (/^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/.test(email)) {
@@ -77,7 +77,7 @@ const LoginForm: React.FC<UserLoginProps> = (props) => {
       await handleAPICreds(email, password, user.id);
       setCurrentUser(user);
 
-      setCookie("growth_10", user, {
+      setCookie("growth_10_03142023", user, {
         path: "/",
         secure: true,
         expires: new Date(Date.now() + 3600 * 1000 * 48),

--- a/src/components/LoginWrapper/index.tsx
+++ b/src/components/LoginWrapper/index.tsx
@@ -15,9 +15,9 @@ const defaultUserContext = {
 export const UserContext = createContext(defaultUserContext);
 
 const SignInWrapper: React.FC<SignInProps> = ({ children, currentUser }) => {
-  const [cookies] = useCookies(["growth_10"]);
+  const [cookies] = useCookies(["growth_10_03142023"]);
 
-  return !currentUser && !cookies.growth_10 ? (
+  return !currentUser && !cookies.growth_10_03142023 ? (
     <Navigate replace to="/" />
   ) : (
     <UserContext.Provider value={{ currentUser }}>

--- a/src/components/NavBar/NavMenu.tsx
+++ b/src/components/NavBar/NavMenu.tsx
@@ -40,10 +40,10 @@ const NavMenu = ({
   setCurrentUser,
 }: NavMenuProps): JSX.Element => {
   const classes = useStyles();
-  const removeCookie = useCookies(["growth_10"])[2];
+  const removeCookie = useCookies(["growth_10_03142023"])[2];
 
   const logoutUser = () => {
-    removeCookie("growth_10", { path: "/" });
+    removeCookie("growth_10_03142023", { path: "/" });
     setCurrentUser(null);
   };
 

--- a/src/components/RegisterForm/index.tsx
+++ b/src/components/RegisterForm/index.tsx
@@ -31,7 +31,7 @@ const RegisterForm: React.FC<UserLoginProps> = (props) => {
   const [userFirstNameError, setUserFirstNameError] = useState<boolean>(false);
   const [userLastNameError, setUserLastNameError] = useState<boolean>(false);
   const [inviteCodeError, setInviteCodeError] = useState<boolean>(false);
-  const [, setCookie] = useCookies(["growth_10"]);
+  const [, setCookie] = useCookies(["growth_10_03142023"]);
   const [checkedTerms, setCheckedTerms] = useState<boolean>(false);
 
   const validateEmail = () => {
@@ -114,7 +114,7 @@ const RegisterForm: React.FC<UserLoginProps> = (props) => {
       }
 
       setCurrentUser(createUser.data[0]);
-      setCookie("growth_10", createUser.data[0], {
+      setCookie("growth_10_03142023", createUser.data[0], {
         path: "/",
         secure: true,
         expires: new Date(Date.now() + 3600 * 1000 * 48),


### PR DESCRIPTION
changing the name of the cookie that is set and stored will force logouts of all users and with the loginwrapper in place, re-routes them to login. 