### PR TITLE
fix(booking confirmation): restore booking confirmation widget, men-106

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,7 +82,7 @@ function App() {
             path="/search"
             element={
               <SignInWrapper currentUser={currentUser}>
-                <CoachSearchV2 />
+                <CoachSearchV2 currentUser={currentUser} />
               </SignInWrapper>
             }
           />

--- a/src/views/CoachBio/index.tsx
+++ b/src/views/CoachBio/index.tsx
@@ -21,14 +21,13 @@ import {
   Wrap,
 } from "@chakra-ui/react";
 import React, { useEffect, useState } from "react";
-import { InlineWidget, useCalendlyEventListener } from "react-calendly";
+import { InlineWidget } from "react-calendly";
 import { CoachType, CurrentUserProps } from "../../types";
 import { GoGlobe } from "react-icons/go";
 import { SiLinkedin } from "react-icons/si";
 import { mixpanelEvent } from "../../helpers";
 import PageWrapper from "../../components/PageWrapper";
 import { menApiAuthClient } from "../../clients/mentumm";
-import { useNavigate } from "react-router";
 
 const CoachBio: React.FC<CurrentUserProps> = ({ currentUser }) => {
   const [coach, setCoach] = useState<CoachType>(null);
@@ -40,13 +39,6 @@ const CoachBio: React.FC<CurrentUserProps> = ({ currentUser }) => {
   const windowUrl = window.location.toString().toLowerCase();
   const slug = windowUrl.substring(windowUrl.lastIndexOf("/") + 1);
   const coachId = slug.split("-");
-  const navigate = useNavigate();
-  useCalendlyEventListener({
-    onEventScheduled: () =>
-      setTimeout(() => {
-        navigate("/booking-confirmation");
-      }, 1000),
-  });
 
   useEffect(() => {
     const loadCoach = async () => {
@@ -154,6 +146,10 @@ const CoachBio: React.FC<CurrentUserProps> = ({ currentUser }) => {
                           url={coach ? coach.booking_url : null}
                           utm={{
                             utmSource: coach ? String(coach.id) : null,
+                          }}
+                          prefill={{
+                            email: currentUser.email,
+                            name: `${currentUser.first_name} ${currentUser.last_name}`,
                           }}
                         />
                       </ModalBody>

--- a/src/views/CoachSearchV2/index.tsx
+++ b/src/views/CoachSearchV2/index.tsx
@@ -8,16 +8,20 @@ import {
   Spinner,
   Text,
 } from "@chakra-ui/react";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import PageWrapper from "../../components/PageWrapper";
 import Coach from "../../components/Coach";
 import { menApiAuthClient } from "../../clients/mentumm";
 import axios from "axios";
+import { useSearchParams, useNavigate } from "react-router-dom";
 
-export const CoachSearchV2 = () => {
+export const CoachSearchV2 = ({ currentUser }) => {
   const [searchTerm, setSearchTerm] = useState("");
   const [coaches, setCoaches] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [searchParams] = useSearchParams();
+  const [coachBooked, setCoachBooked] = useState<boolean>(null);
+  const navigate = useNavigate();
 
   const handleChange = (value: string) => {
     setSearchTerm(value);
@@ -63,6 +67,50 @@ export const CoachSearchV2 = () => {
       controller.abort();
     };
   }, [searchTerm]);
+
+  useEffect(() => {
+    // these are for the calendly redirect url params
+    const event_type_uuid = searchParams.get("event_type_uuid");
+    const event_type_name = searchParams.get("event_type_name");
+    const event_start_time = searchParams.get("event_start_time");
+    const event_end_time = searchParams.get("event_end_time");
+    const invitee_uuid = searchParams.get("invitee_uuid");
+    const invitee_full_name = searchParams.get("invitee_full_name");
+    const invitee_email = searchParams.get("invitee_email");
+    const utmSource = searchParams.get("utm_source");
+
+    const bookCoach = async () => {
+      try {
+        const bookedCoach = await menApiAuthClient().post("/user/book-coach", {
+          user_id: currentUser.id,
+          coach_id: utmSource,
+          event_end_time,
+          event_start_time,
+          event_type_name,
+          event_type_uuid,
+          invitee_email,
+          invitee_full_name,
+          invitee_uuid,
+        });
+
+        if (bookedCoach) {
+          setCoachBooked(true);
+        }
+      } catch (error) {
+        throw new Error("Could not save booking!");
+      }
+    };
+
+    if (!coachBooked && invitee_email && currentUser?.id) {
+      bookCoach();
+    } else if (!invitee_email) {
+      setCoachBooked(false);
+    }
+  }, [searchParams, coachBooked, currentUser]);
+
+  if (coachBooked) {
+    navigate("/booking-confirmation");
+  }
 
   return (
     <PageWrapper title="All Mentumm Coaches" backTo="/home">

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -71,17 +71,6 @@ const Home: React.FC<IProps> = ({ currentUser }) => {
     <Container maxW={1270}>
       <Stack justifyContent="space-between" direction="row" mt={14} mb={8}>
         <Heading>Welcome Back, {currentUser?.first_name}</Heading>
-        {/* <Button
-          as={Link}
-          to="/search"
-          background="#2cbdbe"
-          color="#fff"
-          _hover={{ bg: "#3CA8AB" }}
-          mt={2}
-          style={{ zIndex: 0 }}
-        >
-          PICK A TOPIC
-        </Button> */}
       </Stack>
 
       <HomeMonthlyLeadershipWorkshop />


### PR DESCRIPTION
There isn't a great way to test this on staging but one way that might work is, if you have your own coach and calendly account live on the database, change your confirmation reroute URL to https://mentumm-portal-staging-pr-114.onrender.com/search and book a session. It should then save to the db and show on the home page

Otherwise we'll have to test this when it goes live on prod