### PR TITLE
fix(CoachingStyle): add missing 'kind' field for proper coach style tag updates

### DIFF
--- a/src/views/Coach/EditProfile/index.tsx
+++ b/src/views/Coach/EditProfile/index.tsx
@@ -75,7 +75,7 @@ export const EditProfile = ({ currentUser, setCurrentUser }) => {
         mixpanelEvent("Coach Edit Profile Viewed", {
           "Coach ID": coach.id,
           "Coach Name": `${coach.first_name} ${coach.last_name}`,
-          "Coach Styles": coachStyles.map((style) => style.name),
+          "Coach Styles": coach.styles.map((style) => style.name),
         });
       } catch (error) {
         console.log("Problem loading Coach Profile", error);

--- a/src/views/GetStarted/CoachingStyle/index.tsx
+++ b/src/views/GetStarted/CoachingStyle/index.tsx
@@ -136,6 +136,7 @@ const CoachingStyle: React.FC<CoachingStyleProps> = ({ currentUser, isCoach }) =
       .post(`${envConfig.API_URL}/v1/user/tags`, {
         tag_ids: checkedItems,
         user_id: currentUser.id,
+        kind: 'style',
         clear: true,
       })
       .then(() => {


### PR DESCRIPTION
a 500 error was given on staging during the flow of a coach updating their coach style tags. This was due to an additional request field being added on a separate PR for coach expertise. The addition of the 'kind' field will ensure that only the designated 'kind' of tag will be updated for a coach while leaving the other 'kind's of tags untouched, preserving a coach's tag choices. 