### PR TITLE
fix(EditProfile): made expertise tags one line, wrap in container; MEN-162

### DIFF
--- a/src/views/Coach/EditProfile/index.tsx
+++ b/src/views/Coach/EditProfile/index.tsx
@@ -15,6 +15,8 @@ import {
   InputRightElement,
   Tag,
   HStack,
+  Wrap,
+  WrapItem,
 } from "@chakra-ui/react";
 import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router";
@@ -650,18 +652,22 @@ export const EditProfile = ({ currentUser, setCurrentUser }) => {
                         </FormLabel>
                       </FormControl>
                       <Box>
-                        <HStack
+                        <Wrap
                           mt={2}
                           spacing={2}>
                           {
                             coachExpertise.length ?
                               (coachExpertise.map((style, i) =>
-                                <Tag
-                                  key={i}
-                                  color="white"
-                                  bg="blue.600">
-                                  {style.name}
-                                </Tag>))
+                                <WrapItem>
+                                  <Tag
+                                    whiteSpace="nowrap"
+                                    minW="auto"
+                                    key={i}
+                                    color="white"
+                                    bg="blue.600">
+                                    {style.name}
+                                  </Tag>
+                                </WrapItem>))
                               :
                               (<Link to={`/coach/${currentUser.id}/expertise`}>
                                 <Tag
@@ -671,7 +677,7 @@ export const EditProfile = ({ currentUser, setCurrentUser }) => {
                                 </Tag>
                               </Link>)
                           }
-                        </HStack>
+                        </Wrap>
                       </Box>
                     </Box>
                     <Box flexBasis="100%" marginTop={4} marginBottom={6}>


### PR DESCRIPTION
Ensured tags only take up one line regardless of length, and that they wrap if their combined length is wider than their parent:
<img width="1026" alt="Screenshot 2023-07-12 at 1 40 55 AM" src="https://github.com/mentumm/mentumm-front-end/assets/13356082/cf1c3fe0-780a-460b-ac08-9e81d43fbb7b">
