### PR TITLE
fix(app): remove references to location in favor of city, state; Men-170

### DIFF
--- a/src/components/Coach/index.tsx
+++ b/src/components/Coach/index.tsx
@@ -67,7 +67,7 @@ const generateCoachTags = (tags: TagType[], slug: string) => {
 const Coach: React.FC<CoachProps> = (props) => {
   const classes = useStyles();
   const { coachInfo, slug, booking, currentUser } = props;
-  const { first_name, last_name, expertise, location, photo_url } = coachInfo;
+  const { first_name, last_name, expertise, city, state, photo_url } = coachInfo;
 
   return (
     <Link to={`/coach/${generateCoachUrl(coachInfo)}`} className={classes.root}>
@@ -91,7 +91,7 @@ const Coach: React.FC<CoachProps> = (props) => {
               <Stack mt="1">
                 <HStack fontSize="md" mt={2}>
                   <Icon as={GoGlobe} color="gray.500" />
-                  <Text>{location ? location : null}</Text>
+                  <Text>{(city && state) && `${city}, ${state}`}</Text>
                 </HStack>
               </Stack>
               <Wrap shouldWrapChildren mt={4}>

--- a/src/views/CoachBio/components/profileHeader.tsx
+++ b/src/views/CoachBio/components/profileHeader.tsx
@@ -23,10 +23,10 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({ coach }) => {
         {coach && `${coach.first_name} ${coach.last_name}`}
       </Heading>
       <HStack spacing={8} fontSize="md">
-        {(coach && coach.location) && (
+        {(coach && coach.city && coach.state) && (
           <Box display='inherit' alignItems='center'>
             <Icon as={GoGlobe} color="gray.500" />
-            <Text ml={2} >{coach.location}</Text>
+            <Text ml={2} >{`${coach.city}, ${coach.state}`}</Text>
           </Box>
         )}
         <Box display='inherit' alignItems='center'>


### PR DESCRIPTION
Removed any traces of the `location` User field for views/components. 

Since we have not migrated the database away from location entirely (yet), this PR does not remove every reference to `location`, such as in the `type` definitions. 

any User's geographic location is now only rendered via the `city` and `state` properties only. 